### PR TITLE
Add install options for graphite-web package

### DIFF
--- a/manifests/graphite_reqs.pp
+++ b/manifests/graphite_reqs.pp
@@ -21,6 +21,7 @@ class learning::graphite_reqs {
   }
   package { 'graphite-web':
     ensure => present,
+    install_options => { 'install-lib' => '/usr/lib/python2.7/site-packages/', 'prefix' => '/usr' },
   }
   package { 'carbon':
     ensure => present,


### PR DESCRIPTION
By default, the graphite-web package installs in a location that
pip doesn't recognize. Adding install options seems to fix this
issue.
See https://github.com/graphite-project/graphite-web/issues/1228