### PR TITLE
Add graphite-web package workaround

### DIFF
--- a/manifests/graphite_reqs.pp
+++ b/manifests/graphite_reqs.pp
@@ -20,12 +20,20 @@ class learning::graphite_reqs {
     ensure => '0.4',
   }
   package { 'graphite-web':
-    ensure => present,
+    ensure => '0.9.13',
   }
   package { 'carbon':
-    ensure => present,
+    ensure => '0.9.13',
   }
   package { 'whisper':
-    ensure => present,
+    ensure => '0.9.13',
+  }
+  # Workaround for package installation target that isn't recognized by
+  # pip.
+  # https://github.com/graphite-project/carbon/issues/86
+  file { '/usr/lib/python2.6/site-packages/graphite_web-0.9.13-py2.6.egg-info'
+    target  => '/opt/graphite/webapp/graphite_web-0.9.13-py2.6.egg-info',
+    require => Package['graphite-web'],
+    ensure  => link,
   }
 }


### PR DESCRIPTION
By default, the graphite-web package installs in a location that
pip doesn't recognize. Adding a symlink from the target to a location
recognized by pip ought to fix this.