### PR TITLE
Revert "remove the /etc/securetty file to permit allthettys"

### DIFF
--- a/manifests/abalone.pp
+++ b/manifests/abalone.pp
@@ -2,8 +2,11 @@ class learning::abalone {
 
   include ::abalone
 
-  file { '/etc/securetty':
-    ensure => absent,
+  range("0","15").each |Integer $number| {
+    file_line { "securetty_pts_${number}":
+      path => '/etc/securetty',
+      line => "pts/${number}"
+    }
   }
 
 }


### PR DESCRIPTION
Reverts puppetlabs/pltraining-learning#103

It looks like there are some startup processes that get upset if this isn't present, so I'll have to find a better work-around.