### PR TITLE
Increased memory for slower CPU systems to reduce GC-driven timeouts

### DIFF
--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -4,15 +4,15 @@ puppet_enterprise::profile::puppetdb::listen_address: '0.0.0.0'
 puppet_enterprise::profile::amq::broker::heap_mb: '96'
 puppet_enterprise::profile::master::file_sync_enabled: false
 puppet_enterprise::profile::master::java_args:
-  Xmx: '256m'
+  Xmx: '512m'
   Xms: '256m'
   'XX:+UseG1GC': ''
 puppet_enterprise::profile::puppetdb::java_args:
-  Xmx: '256m'
+  Xmx: '512m'
   Xms: '256m'
   'XX:+UseG1GC': ''
 puppet_enterprise::profile::console::java_args:
-  Xmx: '224m'
+  Xmx: '512m'
   Xms: '128m'
   'XX:+UseG1GC': ''
 puppet_enterprise::master::puppetserver::jruby_max_active_instances: 1  #PE3.7.2 only


### PR DESCRIPTION
Josh has requested this PR to help with hosts that have slow CPUs like mine.

See https://tickets.puppetlabs.com/browse/LEARNVM-446 for lengthy investigation.